### PR TITLE
bugfix: mismatch formula

### DIFF
--- a/components/sections/control/index.js
+++ b/components/sections/control/index.js
@@ -96,7 +96,7 @@ var Control = React.createClass({
       this.drawLerpBox(api, dim, pad, p);
       var t = (p.x-pad)/fwh;
       this.drawLerpPoint(api, (1-t)*(1-t)*(1-t), pad, fwh, p);
-      this.drawLerpPoint(api, 2*(1-t)*(1-t)*(t), pad, fwh, p);
+      this.drawLerpPoint(api, 3*(1-t)*(1-t)*(t), pad, fwh, p);
       this.drawLerpPoint(api, 3*(1-t)*(t)*(t), pad, fwh, p);
       this.drawLerpPoint(api, (t)*(t)*(t), pad, fwh, p);
     }

--- a/components/sections/whatis/index.js
+++ b/components/sections/whatis/index.js
@@ -119,7 +119,7 @@ var Whatis = React.createClass({
       <section>
         <SectionHeader {...this.props} />
 
-        <p>Playing with the points for curves may have given you a feel for how Bézier curves behaves, but
+        <p>Playing with the points for curves may have given you a feel for how Bézier curves behave, but
         what <em>are</em> Bézier curves, really? There are two ways to explain what a Bézier curve is, and
         they turn out to be the entirely equivalent, but one of them uses complicated maths, and the other
         uses really simple maths. So... let's start with the simple explanation:</p>


### PR DESCRIPTION
 the 'second term' interpolation percentages indicator doesn't take the path of 'second term ' curve path.
