### PR TITLE
FIx broken URL to node-canvas repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Work is still underway on this new version, see https://github.com/Pomax/BezierI
 
 ## Building everything
 
-Use the active Node LTS (currently v16) or higher, with all the project dependencies installed via `npm install`. Note that [node-canvas](https://github.com/Automattic/node-canva) will need you to [install some Cairo libs/headers](https://github.com/Automattic/node-canvas#compiling) using your OS's package manager, with [special instructions for Windows users](https://github.com/Automattic/node-canvas/wiki/Installation:-Windows) because Windows doesn't come with the same kind of package management that Unixy systems do. To successfully compile, GTK is _required_, but JPEG support is not (this repo's code only generates PNG images).
+Use the active Node LTS (currently v16) or higher, with all the project dependencies installed via `npm install`. Note that [node-canvas](https://github.com/Automattic/node-canvas) will need you to [install some Cairo libs/headers](https://github.com/Automattic/node-canvas#compiling) using your OS's package manager, with [special instructions for Windows users](https://github.com/Automattic/node-canvas/wiki/Installation:-Windows) because Windows doesn't come with the same kind of package management that Unixy systems do. To successfully compile, GTK is _required_, but JPEG support is not (this repo's code only generates PNG images).
 
 Also note that you will need a TeX installation with several dependencies: on Windows, install [MiKTeX](https://miktex.org/download) and set it up so that it automatically installs things as needed. On Linux/Unix/etc, you'll need to install the following packages :
 


### PR DESCRIPTION
A link to `node-canvas` repo in `README.md` had a typo: it would link to `https://github.com/Automattic/node-canva` (no 's' at the end) that does not exist and cause a 404 when clicked. This pull request fixes this issue.